### PR TITLE
exiftool.py: remove +e in exiftool executable name

### DIFF
--- a/exiftool.py
+++ b/exiftool.py
@@ -331,7 +331,7 @@ class ExifTool(object):
 			warnings.warn("ExifTool already running; doing nothing.")
 			return
 
-		proc_args = [self.executable+'e', "-stay_open", "True",  "-@", "-", "-common_args"]
+		proc_args = [self.executable, "-stay_open", "True",  "-@", "-", "-common_args"]
 		proc_args.extend(self.common_args) # add the common arguments
 
 		logging.debug(proc_args)


### PR DESCRIPTION
`+'e'` is introduced in commit 7b0fbfb. This "fix" might break on Windows. Tested on macOS.

It seems that the logic of commit 7b0fbfb is to dispatch on the case of Windows, default exiftool executable name as `exiftool.exe`, but somehow it adds `e` to the end later, making it calling `exiftool.exee` on win32 and `exiftoole` else (including macOS and Linux), while before commit 7b0fbfb it is calling `exiftool` by default in all cases.