### PR TITLE
exiftool.py: use ujson when it exists

### DIFF
--- a/exiftool.py
+++ b/exiftool.py
@@ -60,7 +60,10 @@ import select
 import sys
 import subprocess
 import os
-import json
+try:
+	import ujson as json
+except ImportError:
+	import json
 import warnings
 import logging
 import codecs


### PR DESCRIPTION
> UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.5+ and 3.
>
> May be used as a drop in replacement for most other JSON parsers for Python:

from <https://pypi.org/project/ujson/>