### PR TITLE
Support '-w' flag in common_args

### DIFF
--- a/exiftool.py
+++ b/exiftool.py
@@ -514,7 +514,9 @@ class ExifTool(object):
 		# which will return something like
 		# image files read
 		# output files created
-		if not self.no_output:
+		if self.no_output:
+			print(res)
+		else:
 			try:
 				return json.loads(res.decode("utf-8"))
 			except UnicodeDecodeError as e:

--- a/exiftool.py
+++ b/exiftool.py
@@ -510,17 +510,18 @@ class ExifTool(object):
 		# http://stackoverflow.com/a/5552623/1318758
 		# https://github.com/jmathai/elodie/issues/127
 		res = self.execute(b"-j", *params)
-		# res can be invalid json if `-w` flag is specified in common_args
+		try:
+			res_decoded = res.decode("utf-8")
+		except UnicodeDecodeError:
+			res_decoded = res.decode("latin-1")
+		# res_decoded can be invalid json if `-w` flag is specified in common_args
 		# which will return something like
 		# image files read
 		# output files created
 		if self.no_output:
-			print(res)
+			print(res_decoded)
 		else:
-			try:
-				return json.loads(res.decode("utf-8"))
-			except UnicodeDecodeError as e:
-				return json.loads(res.decode("latin-1"))
+			return json.loads(res_decoded)
 
 	# allows adding additional checks (#11)
 	def get_metadata_batch_wrapper(self, filenames, params=None):

--- a/exiftool.py
+++ b/exiftool.py
@@ -314,6 +314,8 @@ class ExifTool(object):
 		else:
 			raise TypeError("common_args not a list of strings")
 
+		self.no_output = '-w' in common_args
+
 
 	def start(self):
 		"""Start an ``exiftool`` process in batch mode for this instance.
@@ -507,10 +509,16 @@ class ExifTool(object):
 		# Try utf-8 and fallback to latin.
 		# http://stackoverflow.com/a/5552623/1318758
 		# https://github.com/jmathai/elodie/issues/127
-		try:
-			return json.loads(self.execute(b"-j", *params).decode("utf-8"))
-		except UnicodeDecodeError as e:
-			return json.loads(self.execute(b"-j", *params).decode("latin-1"))
+		res = self.execute(b"-j", *params)
+		# res can be invalid json if `-w` flag is specified in common_args
+		# which will return something like
+		# image files read
+		# output files created
+		if not self.no_output:
+			try:
+				return json.loads(res.decode("utf-8"))
+			except UnicodeDecodeError as e:
+				return json.loads(res.decode("latin-1"))
 
 	# allows adding additional checks (#11)
 	def get_metadata_batch_wrapper(self, filenames, params=None):


### PR DESCRIPTION
When '-w' flag is added, exiftool writes the json in a file instead of putting it in stdout. This change handle that case to print the string "# image files read\n# output files created\n" that exiftool put to stdout, and return None, which is expected if the result is written to files.