### PR TITLE
Update install scripts with new module name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires = exiftool
+requires = pyexiftool

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,4 @@ setup(  name="PyExifTool",
 			"Programming Language :: Python :: 2.7",
 			"Programming Language :: Python :: 3",
 			"Topic :: Multimedia"],
-		py_modules=["exiftool"])
+		py_modules=["pyexiftool"])


### PR DESCRIPTION
Since the package name changed in de22a96, the setup script doesn't copy pyexiftool on install. This updates the script to use the new package name.