### PR TITLE
Fix NoneType exception in common_args check

### DIFF
--- a/pyexiftool.py
+++ b/pyexiftool.py
@@ -317,7 +317,7 @@ class ExifTool(object):
 		else:
 			raise TypeError("common_args not a list of strings")
 
-		self.no_output = '-w' in common_args
+		self.no_output = '-w' in self.common_args
 
 
 	def start(self):


### PR DESCRIPTION
At the end of `ExifTool.__init__`,  there's an iteration over the provided `common_args` even if it's `None`.  This causes a `NoneType is not iterable` exception if nothing is provided. This fix iterates over the initialized `self.common_args` instead.