### PR TITLE
update url for documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Documentation
 -------------
 
 The documentation is available at
-http://smarnach.github.com/pyexiftool/.
+http://smarnach.github.io/pyexiftool/.
 
 Licence
 -------


### PR DESCRIPTION
This change fixes the documentation URL in `README.rst`.

The URL for the library documentation no longer works. `*.github.com` TLD has been deprecated and replaced by `*.github.io`. 