### PR TITLE
`copy_tags` Encode parameters + tests for TestTagCopying

### DIFF
--- a/exiftool/exiftool.py
+++ b/exiftool/exiftool.py
@@ -648,7 +648,9 @@ class ExifTool(object):
 
 	def copy_tags(self, fromFilename, toFilename):
 		"""Copy all tags from one file to another."""
-		self.execute("-overwrite_original", "-TagsFromFile", fromFilename, toFilename)
+		params = ["-overwrite_original", "-TagsFromFile", fromFilename, toFilename]
+		params_utf8 = [x.encode('utf-8') for x in params]
+		self.execute(*params_utf8)
 
 
 	def set_tags_batch(self, tags, filenames):


### PR DESCRIPTION
Currently, [`copy_tags`](https://github.com/sylikc/pyexiftool/blob/1e9b4b34abac6d4294a5958494c7b1b4c1391589/exiftool/exiftool.py#L649) fails because the parameters are not encoded properly.

Now, I don't necessarily understand all this encoding of parameters, and I don't know why [`execute`](https://github.com/sylikc/pyexiftool/blob/1e9b4b34abac6d4294a5958494c7b1b4c1391589/exiftool/exiftool.py#L419) cannot take care of it, although this was apparently tried:

https://github.com/sylikc/pyexiftool/blob/1e9b4b34abac6d4294a5958494c7b1b4c1391589/exiftool/exiftool.py#L442

Anyways, [`set_tags_batch`](https://github.com/sylikc/pyexiftool/blob/1e9b4b34abac6d4294a5958494c7b1b4c1391589/exiftool/exiftool.py#L654) and [`set_keywords_batch`](https://github.com/sylikc/pyexiftool/blob/1e9b4b34abac6d4294a5958494c7b1b4c1391589/exiftool/exiftool.py#L705) encode their parameters before passing them along, and doing to for `copy_tags` works in my local monkeypatched version of pyexiftool.