### PR TITLE
Fix experimental class

### DIFF
--- a/exiftool/experimental.py
+++ b/exiftool/experimental.py
@@ -134,7 +134,7 @@ class ExifToolAlpha(ExifToolHelper):
 			execute_params.extend(params)
 		execute_params.extend(filenames)
 
-		result = self.execute_json(execute_params)
+		result = self.execute_json(*execute_params)
 
 		if result:
 			try:

--- a/exiftool/experimental.py
+++ b/exiftool/experimental.py
@@ -145,7 +145,7 @@ class ExifToolAlpha(ExifToolHelper):
 				self.run()
 
 				if retry_on_error:
-					result = self.execute_json_filenames(filenames, params, retry_on_error=False)
+					result = self.execute_json_wrapper(filenames, params, retry_on_error=False)
 				else:
 					raise error
 		else:

--- a/exiftool/experimental.py
+++ b/exiftool/experimental.py
@@ -322,7 +322,7 @@ class ExifToolAlpha(ExifToolHelper):
 			returned_source_file = result[i].get('SourceFile')
 			requested_file = file_paths[i]
 
-			if returned_source_file != requested_file:
+			if Path(returned_source_file) != Path(requested_file):
 				raise IOError(f"exiftool returned data for file {returned_source_file}, but expected was {requested_file}")
 
 	# ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Bug Fixes for Experimental Class:

1. Fixed execute_json argument unpacking - now correctly passes individual strings to exiftool instead of a stringified list
2. Fixed Windows path comparison by normalizing backslash/forward slash differences
3. Fixed execute_json_wrapper retry logic to call itself instead of non-existent function